### PR TITLE
Add category search to books

### DIFF
--- a/SpringBoot/src/main/java/com/example/demo/controller/BookController.java
+++ b/SpringBoot/src/main/java/com/example/demo/controller/BookController.java
@@ -45,7 +45,8 @@ public class BookController {
                               @RequestParam(defaultValue = "10") Integer pageSize,
                               @RequestParam(defaultValue = "") String search1,
                               @RequestParam(defaultValue = "") String search2,
-                              @RequestParam(defaultValue = "") String search3){
+                              @RequestParam(defaultValue = "") String search3,
+                              @RequestParam(defaultValue = "") String search4){
         LambdaQueryWrapper<Book> wrappers = Wrappers.<Book>lambdaQuery();
         if(StringUtils.isNotBlank(search1)){
             wrappers.like(Book::getIsbn,search1);
@@ -55,6 +56,9 @@ public class BookController {
         }
         if(StringUtils.isNotBlank(search3)){
             wrappers.like(Book::getAuthor,search3);
+        }
+        if(StringUtils.isNotBlank(search4)){
+            wrappers.like(Book::getCategory,search4);
         }
         Page<Book> BookPage =BookMapper.selectPage(new Page<>(pageNum,pageSize), wrappers);
         return Result.success(BookPage);

--- a/SpringBoot/src/main/java/com/example/demo/entity/Book.java
+++ b/SpringBoot/src/main/java/com/example/demo/entity/Book.java
@@ -24,6 +24,7 @@ public class Book {
     private String name;
     private BigDecimal price;
     private String author;
+    private String category;
     private Integer borrownum;
     private String publisher;
     @JsonFormat(locale="zh",timezone="GMT+8", pattern="yyyy-MM-dd")

--- a/sql/springboot-vue.sql
+++ b/sql/springboot-vue.sql
@@ -27,6 +27,7 @@ CREATE TABLE `book`  (
   `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL COMMENT '名称',
   `price` decimal(10, 2) NULL DEFAULT NULL COMMENT '价格',
   `author` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL COMMENT '作者',
+  `category` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL COMMENT '分类',
   `publisher` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT NULL COMMENT '出版社',
   `create_time` date NULL DEFAULT NULL COMMENT '出版时间',
   `status` varchar(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '0：未归还 1：已归还',
@@ -37,12 +38,12 @@ CREATE TABLE `book`  (
 -- ----------------------------
 -- Records of book
 -- ----------------------------
-INSERT INTO `book` VALUES (9, '12341541321', '十万个为什么', 15.00, '小王', '宁波大学出版社', '2014-12-16', '1', 7);
-INSERT INTO `book` VALUES (10, '2312315132131', '五万个为什么', NULL, NULL, NULL, NULL, '1', 3);
-INSERT INTO `book` VALUES (11, '25213121232', '一万个为什么', NULL, NULL, NULL, NULL, '1', 5);
-INSERT INTO `book` VALUES (12, '3213123123', '操作系统', NULL, NULL, NULL, NULL, '0', 8);
-INSERT INTO `book` VALUES (13, '345621212321', '伊索寓言', NULL, NULL, NULL, NULL, '0', 9);
-INSERT INTO `book` VALUES (15, '54112312321', '格林童话', NULL, NULL, NULL, NULL, '1', 1);
+INSERT INTO `book` VALUES (9, '12341541321', '十万个为什么', 15.00, '小王', '科普', '宁波大学出版社', '2014-12-16', '1', 7);
+INSERT INTO `book` VALUES (10, '2312315132131', '五万个为什么', NULL, NULL, NULL, NULL, NULL, '1', 3);
+INSERT INTO `book` VALUES (11, '25213121232', '一万个为什么', NULL, NULL, NULL, NULL, NULL, '1', 5);
+INSERT INTO `book` VALUES (12, '3213123123', '操作系统', NULL, NULL, NULL, NULL, NULL, '0', 8);
+INSERT INTO `book` VALUES (13, '345621212321', '伊索寓言', NULL, NULL, NULL, NULL, NULL, '0', 9);
+INSERT INTO `book` VALUES (15, '54112312321', '格林童话', NULL, NULL, NULL, NULL, NULL, '1', 1);
 
 -- ----------------------------
 -- Table structure for bookwithuser

--- a/vue/src/views/Book.vue
+++ b/vue/src/views/Book.vue
@@ -19,6 +19,11 @@
             <template #prefix><el-icon class="el-input__icon"><search /></el-icon></template>
           </el-input>
         </el-form-item >
+        <el-form-item label="分类" >
+          <el-input v-model="search4" placeholder="请输入分类"  clearable>
+            <template #prefix><el-icon class="el-input__icon"><search /></el-icon></template>
+          </el-input>
+        </el-form-item >
         <el-form-item>
           <el-button type="primary" style="margin-left: 1%" @click="load" size="mini" >
             <svg-icon iconClass="search"/>查询</el-button>
@@ -61,6 +66,7 @@
       <el-table-column prop="name" label="图书名称" />
       <el-table-column prop="price" label="价格" sortable/>
       <el-table-column prop="author" label="作者" />
+      <el-table-column prop="category" label="分类" />
       <el-table-column prop="publisher" label="出版社" />
       <el-table-column prop="createTime" label="出版时间" sortable/>
       <el-table-column prop="status" label="状态">
@@ -136,6 +142,9 @@
           <el-form-item label="作者">
             <el-input style="width: 80%" v-model="form.author"></el-input>
           </el-form-item>
+          <el-form-item label="分类">
+            <el-input style="width: 80%" v-model="form.category"></el-input>
+          </el-form-item>
           <el-form-item label="出版社">
             <el-input style="width: 80%" v-model="form.publisher"></el-input>
           </el-form-item>
@@ -167,6 +176,9 @@
           </el-form-item>
           <el-form-item label="作者">
             <el-input style="width: 80%" v-model="form.author"></el-input>
+          </el-form-item>
+          <el-form-item label="分类">
+            <el-input style="width: 80%" v-model="form.category"></el-input>
           </el-form-item>
           <el-form-item label="出版社">
             <el-input style="width: 80%" v-model="form.publisher"></el-input>
@@ -231,6 +243,7 @@ export default {
           search1: this.search1,
           search2: this.search2,
           search3: this.search3,
+          search4: this.search4,
         }
       }).then(res =>{
         console.log(res)
@@ -274,6 +287,7 @@ export default {
       this.search1 = ""
       this.search2 = ""
       this.search3 = ""
+      this.search4 = ""
       this.load()
     },
 
@@ -487,6 +501,7 @@ export default {
       search1:'',
       search2:'',
       search3:'',
+      search4:'',
       total:10,
       currentPage:1,
       pageSize: 10,


### PR DESCRIPTION
## Summary
- add `category` field to Book entity
- support category search in BookController
- update example DB schema and seed data for category
- expose category fields and filters in the Book view

## Testing
- `npm install` *(fails: Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6856bfc32958832a8606291a971acc9a